### PR TITLE
Add series navigation to blog posts

### DIFF
--- a/assets/css/site.css
+++ b/assets/css/site.css
@@ -1,0 +1,83 @@
+.post-series {
+  margin: 2rem 0;
+  border: 1px solid #ddd;
+}
+
+.post-series h2 {
+  margin: 0;
+  padding: 0.85rem 1rem;
+  border-bottom: 1px solid #ddd;
+  color: #4054d6;
+  font-size: 1.1rem;
+  line-height: 1.3;
+}
+
+.post-series ol {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+.post-series__item + .post-series__item {
+  border-top: 1px solid #eee;
+}
+
+.post-series__row {
+  display: grid;
+  grid-template-columns: 2.1rem minmax(0, 1fr);
+  gap: 0.8rem;
+  align-items: center;
+  padding: 0.85rem 1rem;
+  color: #555;
+}
+
+a.post-series__row:link,
+a.post-series__row:active,
+a.post-series__row:visited {
+  color: #555;
+}
+
+a.post-series__row:hover {
+  background: whitesmoke;
+  text-decoration: none;
+}
+
+.post-series__number {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 2rem;
+  height: 2rem;
+  border-radius: 999px;
+  background: #eee;
+  color: #666;
+  font-size: 0.95rem;
+}
+
+.post-series__title {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.post-series__item.is-current .post-series__row {
+  color: #111;
+  font-weight: 700;
+}
+
+.post-series__item.is-current .post-series__number {
+  background: #4054d6;
+  color: white;
+  font-weight: 400;
+}
+
+@media screen and (max-width: 899px) {
+  .post-series {
+    margin: 1.5rem 0;
+  }
+
+  .post-series__title {
+    white-space: normal;
+  }
+}

--- a/includes/series-adotando-pratica-de-notas.html.eex
+++ b/includes/series-adotando-pratica-de-notas.html.eex
@@ -1,0 +1,44 @@
+<%
+  page = @args[:page]
+
+  posts = [
+    %{
+      number: 1,
+      title: "Tomando notas como desenvolvedor de software",
+      url: post("2023-09-23-tomando-notas-como-desenvolvedor-de-software")
+    },
+    %{
+      number: 2,
+      title: "Anotando: Plugins embutidos que utilizo no Obsidian",
+      url: post("2023-09-24-anotando-plugins-embutidos-que-utilizo-no-obsidian")
+    },
+    %{
+      number: 3,
+      title: "Anotando: Plugins da comunidade que utilizo no Obsidian",
+      url: post("2023-10-09-anotando-plugins-da-comunidade-que-utilizo-no-obsidian")
+    }
+  ]
+%>
+
+<nav class="post-series" aria-labelledby="post-series-adotando-pratica-de-notas-title">
+  <h2 id="post-series-adotando-pratica-de-notas-title">Adotando prática de notas (3 partes)</h2>
+  <ol>
+    <%= for item <- posts do %>
+      <% current? = item.url == page.url %>
+      <li class="post-series__item<%= if current?, do: " is-current", else: "" %>">
+        <%= if current? do %>
+          <span class="post-series__row" aria-current="page">
+        <% else %>
+          <a class="post-series__row" href="<%= item.url %>">
+        <% end %>
+            <span class="post-series__number"><%= item.number %></span>
+            <span class="post-series__title"><%= item.title %></span>
+        <%= if current? do %>
+          </span>
+        <% else %>
+          </a>
+        <% end %>
+      </li>
+    <% end %>
+  </ol>
+</nav>

--- a/posts/2023-09-23-tomando-notas-como-desenvolvedor-de-software.md
+++ b/posts/2023-09-23-tomando-notas-como-desenvolvedor-de-software.md
@@ -2,6 +2,7 @@
 title: Tomando notas como desenvolvedor de software
 date: 2023-09-23 00:50:00
 tags: notes
+series: adotando-pratica-de-notas
 ---
 
 Me arrependo profundamente de não tomar notas mais cedo. As notas até existiam, mas geralmente eram coisas pontuais para executar uma tarefa ou algo interessante que encontrei que meses depois eram só anotações "sem utilidade".

--- a/posts/2023-09-24-anotando-plugins-embutidos-que-utilizo-no-obsidian.md
+++ b/posts/2023-09-24-anotando-plugins-embutidos-que-utilizo-no-obsidian.md
@@ -2,6 +2,7 @@
 title: Anotando: Plugins embutidos que utilizo no Obsidian
 date: 2023-09-24 03:00:00
 tags: notes
+series: adotando-pratica-de-notas
 ---
 
 Na [postagem passada](https://wevtimoteo.github.io/posts/2023-09-23-tomando-notas-como-desenvolvedor-de-software.html) eu expliquei como iniciei minha jornada em tomar notas, mas não falei muito do app ([Obsidian](https://obsidian.md)) e quais minhas configurações e plugins.

--- a/posts/2023-10-09-anotando-plugins-da-comunidade-que-utilizo-no-obsidian.md
+++ b/posts/2023-10-09-anotando-plugins-da-comunidade-que-utilizo-no-obsidian.md
@@ -2,6 +2,7 @@
 title: Anotando: Plugins da comunidade que utilizo no Obsidian
 date: 2023-10-09 12:00:00
 tags: notes
+series: adotando-pratica-de-notas
 ---
 
 Na [postagem passada](/posts/2023-09-24-anotando-plugins-embutidos-que-utilizo-no-obsidian.html), eu mostrei quais plugins embutidos do [Obsidian](https://obsidian.md) eu deixo ligado e porquê. Agora é a hora de começar a montar o restante do fluxo de anotações utilizando os plugins da [comunidade](https://obsidian.md/community).

--- a/posts/2025-09-01-ash-framework-em-elixir-o-que-e.md
+++ b/posts/2025-09-01-ash-framework-em-elixir-o-que-e.md
@@ -98,7 +98,12 @@ defmodule MyApp.Catalog.Product do
   end
 
   actions do
-    defaults [:read, :destroy, create: [:name], update: [:name, :status]]
+    defaults [
+      :read,
+      :destroy,
+      create: [:name],
+      update: [:name, :status]
+    ]
   end
 end
 ```
@@ -113,7 +118,7 @@ A diferença é que o Domain não é apenas um módulo com funções públicas. 
 
 Autorização costuma ser uma das primeiras regras a se espalhar.
 
-Um `if current_user.admin?` no controller parece inofensivo. Depois aparece uma variação em uma LiveView. Depois um worker precisa ignorar a regra. Depois uma API pública precisa aplicar uma versão diferente. Em algum momento, entender quem pode fazer o quê exige buscar por condicionais em vários arquivos.
+Um `if current_user.admin?` no controller parece inofensivo. Depois aparece uma variação em uma LiveView. Depois um worker precisa ignorar a regra. Depois uma API pública precisa aplicar uma versão diferente. Em algum momento, entender quem pode fazer o que exige buscar por condicionais em vários arquivos.
 
 Ash oferece [Policies](https://hexdocs.pm/ash/policies.html) para declarar regras de autorização próximas do domínio. A ideia é que uma ação não seja apenas "executável", mas executável por alguém, em determinado contexto, sob determinadas condições.
 
@@ -139,7 +144,7 @@ Eu não olharia para Ash como algo obrigatório em todo projeto Elixir.
 
 Para uma aplicação pequena, com poucas tabelas e regras simples, Phoenix Contexts com Ecto podem ser mais diretos. Você cria schemas, changesets, funções bem nomeadas e segue a vida.
 
-Ash começa a ficar mais atraente quando aparecem sinais como:
+Ash começa a ficar mais atrativo quando aparecem sinais como:
 
 - múltiplas interfaces consumindo o mesmo domínio;
 - regras de autorização crescendo;
@@ -156,13 +161,13 @@ Nesses casos, a pergunta não é "Ash escreve menos código?". Às vezes sim, à
 
 Ash tem curva de aprendizado. Você precisa entender a DSL, o ciclo de vida das actions, a diferença entre changes e validations, como queries são preparadas, como policies são avaliadas, como domains organizam recursos e como as extensões se encaixam.
 
-Para quem vem de Phoenix e Ecto puros, isso pode parecer uma mudança grande. E é. O código deixa de ser apenas um conjunto de funções Elixir explícitas e passa a ter uma camada declarativa forte. Isso traz poder, mas também exige leitura de documentação, familiaridade com convenções e disciplina para não transformar o recurso em um arquivo difícil de navegar.
+Para quem usa Phoenix e Ecto diretamente, isso pode parecer uma mudança grande. E é. O código deixa de ser apenas um conjunto de funções Elixir explícitas e passa a ter uma camada declarativa forte. Isso traz poder, mas também exige leitura de documentação, familiaridade com convenções e disciplina para não transformar o recurso em um arquivo difícil de navegar.
 
 O ponto positivo é que Ash não tenta ser um mundo isolado. Ele conversa com o ecossistema Elixir: pode usar Ecto por baixo via AshPostgres, integrar com Phoenix, trabalhar com Oban, expor APIs e ainda permitir escapes quando uma parte do sistema precisa de algo mais manual.
 
 Para mim, essa é a forma mais saudável de avaliar Ash: não como mágica, mas como uma tentativa de dar mais estrutura para a camada de aplicação em Elixir.
 
-## Fechando
+## Concluindo
 
 Ash muda a forma de modelar aplicações porque desloca o centro do código.
 
@@ -170,4 +175,4 @@ Em vez de espalhar regras entre contexts, controllers, LiveViews, workers e APIs
 
 Isso não torna Ecto obsoleto, não torna Phoenix menos importante e não elimina decisões difíceis. Mas oferece uma alternativa interessante para aplicações onde o domínio começou a ficar maior do que o padrão tradicional estava conseguindo expressar com clareza.
 
-Nos próximos posts da série, vou comparar Ash com Phoenix Contexts, criar um primeiro Resource e entrar aos poucos em actions, policies, LiveView, multi-tenancy, autenticação, calculations e aggregates.
+No [próximo post da série](/posts/2025-09-08-ash-vs-ecto-contexts-quando-usar.html), vou comparar Ash com Phoenix Contexts. Depois, sigo com um primeiro Resource e entro aos poucos em actions, policies, LiveView, multi-tenancy, autenticação, calculations e aggregates.

--- a/posts/2025-09-08-ash-vs-ecto-contexts-quando-usar.md
+++ b/posts/2025-09-08-ash-vs-ecto-contexts-quando-usar.md
@@ -4,13 +4,15 @@ date: 2025-09-08 09:00:00
 tags: ash, ashframework, elixir, phoenix, ecto, ptbr
 ---
 
+No [post anterior da série](/posts/2025-09-01-ash-framework-em-elixir-o-que-e.html), apresentei o problema que o Ash tenta resolver e por que ele muda a forma de modelar aplicações.
+
 Quando alguém começa a olhar para [Ash Framework](https://ash-hq.org/) vindo de [Phoenix](https://phoenixframework.org/) e [Ecto](https://hexdocs.pm/ecto/Ecto.html), uma pergunta aparece rápido: "isso substitui Phoenix Contexts?"
 
 A resposta curta é: não exatamente.
 
-Ash não é um substituto burro de Ecto, nem uma tentativa de apagar o padrão de contexts do Phoenix. Ele é uma camada declarativa de domínio. Isso muda bastante a comparação, porque Ecto e Ash não estão tentando resolver o mesmo problema no mesmo nível.
+Ash não é simplesmente um substituto para Ecto, nem uma tentativa de apagar o padrão de contexts do Phoenix. Ele é uma camada declarativa de domínio. Isso muda bastante a comparação, porque Ecto e Ash não estão tentando resolver o mesmo problema no mesmo nível.
 
-Ecto é excelente para falar com dados. Ele modela schemas, changesets, queries, migrations e integração com bancos relacionais. Phoenix Contexts são uma convenção para organizar uma área da aplicação e expor funções públicas para o restante do sistema.
+Ecto é excelente para lidar com persistência de dados. Ele modela schemas, changesets, queries, migrations e integração com bancos relacionais. Phoenix Contexts são uma convenção para organizar uma área da aplicação e expor funções públicas para o restante do sistema.
 
 Ash tenta responder outra pergunta: quais recursos existem no meu domínio, quais ações são permitidas, quais regras cada ação precisa respeitar e como essas regras podem ser reaproveitadas por diferentes interfaces?
 
@@ -45,7 +47,7 @@ Nesse ponto, o context ainda funciona, mas o contrato do domínio começa a depe
 
 ## Onde Ecto brilha
 
-Eu continuaria usando Ecto puro, com Phoenix Contexts, quando a aplicação tem características como:
+Eu continuaria usando Ecto com Phoenix Contexts quando a aplicação tem características como:
 
 - poucas entidades;
 - regras de autorização simples;
@@ -55,7 +57,7 @@ Eu continuaria usando Ecto puro, com Phoenix Contexts, quando a aplicação tem 
 - equipe confortável com SQL e changesets explícitos;
 - domínio que muda pouco.
 
-Nesses casos, Ash pode parecer pesado. Não porque seja ruim, mas porque você passa a aprender uma DSL, entender actions, domains, policies, resources, preparations e extensions para resolver algo que talvez já estivesse simples.
+Nesses casos, Ash pode adicionar mais estrutura do que a aplicação precisa. Não porque seja ruim, mas porque você passa a aprender uma DSL, entender actions, domains, policies, resources, preparations e extensions para resolver algo que talvez já estivesse simples.
 
 O custo de uma abstração só vale quando ela compra algo real.
 
@@ -83,15 +85,17 @@ Ash tenta concentrar isso em Resources e Actions. Uma ação deixa de ser "uma f
 
 ## Ash não elimina Ecto
 
-Um ponto importante: Ash não significa abandonar Ecto.
+Um ponto importante: usar Ash não significa deixar o Ecto de lado.
 
 Quando você usa Ash com Postgres, normalmente entra o [AshPostgres](https://hexdocs.pm/ash_postgres/) como data layer. Ecto continua existindo por baixo em boa parte da integração com banco. Migrations, tipos, constraints e SQL continuam relevantes.
+
+O que muda na prática é que você não fica com aquele arquivo de schema Ecto gerado à parte como centro da estrutura dos dados. Em Ash, atributos, relacionamentos e ações são declarados no Resource. O AshPostgres usa essa declaração para integrar com o banco, em vez de você manter um schema Ecto separado como centro do modelo.
 
 A diferença é que Ecto deixa de ser a única camada onde o domínio aparece.
 
 Em vez de espalhar regra entre schema, changeset, context e controller, você declara parte importante do comportamento no Resource. O Resource pode ter atributos, relacionamentos, actions, validações, policies, calculations e aggregates.
 
-Isso não é "Ecto, só que mais mágico". É outra forma de organizar a aplicação.
+Na prática, Ash muda onde parte das regras vive e como elas são descritas. É outra forma de organizar a aplicação.
 
 ## Comparando o formato mental
 
@@ -105,11 +109,11 @@ Com Ash, a pergunta muda:
 
 Essa diferença parece pequena, mas muda o desenho da aplicação.
 
-Em Ecto puro, a fronteira do domínio é uma convenção. Em Ash, essa fronteira vira uma estrutura declarativa. Ela fica mais visível para ferramentas, extensões e outras partes do código.
+Com Ecto e Phoenix Contexts, essa fronteira depende principalmente da organização que o time mantém no código. Em Ash, parte dessa fronteira passa a ser declarada na estrutura do Resource. Ela fica mais visível para ferramentas, extensões e outras partes do código.
 
 ## O tradeoff da DSL
 
-Ash tem DSL. Isso pode ser ótimo ou irritante, dependendo do problema.
+Ash usa uma DSL declarativa para descrever recursos, ações e regras. Isso pode ser ótimo ou irritante, dependendo do problema.
 
 O lado bom é que uma DSL bem pensada reduz repetição e torna certas intenções óbvias. Ao ler um Resource, você enxerga rapidamente quais ações existem, quais atributos são públicos, quais validações se aplicam e quais policies protegem a operação.
 
@@ -121,13 +125,13 @@ Se a equipe não compra essa forma de pensar, Ash pode virar uma camada que pouc
 
 Eu escolheria Phoenix Contexts com Ecto quando o sistema é simples, o time quer máxima explicitude e o domínio não tem muita variação de operação.
 
-Também escolheria Ecto puro quando a aplicação é muito específica em SQL, tem pouca necessidade de exposição de APIs e não ganha muito com uma representação declarativa do domínio.
+Também escolheria Ecto com Phoenix Contexts quando a aplicação é muito específica em SQL, tem pouca necessidade de exposição de APIs e não ganha muito com uma representação declarativa do domínio.
 
 Eu consideraria Ash quando a aplicação tem muitas regras transversais: autorização, multi-tenancy, APIs, formulários, workers, imports, actions diferentes para o mesmo recurso e necessidade de manter tudo isso consistente.
 
-Ash também fica mais atraente quando o domínio precisa ser consumido por mais de uma interface. Uma LiveView, uma API JSON, GraphQL e um job interno podem chamar ações com o mesmo contrato, em vez de cada interface reconstruir a lógica do seu jeito.
+Ash também fica mais atrativo quando o domínio precisa ser consumido por mais de uma interface. Uma LiveView, uma API JSON, GraphQL e um job interno podem chamar ações com o mesmo contrato, em vez de cada interface reconstruir a lógica do seu jeito.
 
-## Fechando
+## Concluindo
 
 A comparação mais justa não é "Ash ou Ecto?".
 
@@ -136,3 +140,5 @@ A comparação real é: "Phoenix Contexts com Ecto continuam dando conta do cont
 Se a resposta for "ainda está simples", fique com Ecto e Contexts. É uma escolha madura.
 
 Se a resposta for "estou repetindo autorização, filtros, validações e operações em lugares diferentes", Ash merece uma avaliação séria. Não por hype, mas porque talvez o problema já tenha deixado de ser persistência e passado a ser modelagem de domínio.
+
+No [próximo post da série](/posts/2025-09-15-criando-seu-primeiro-resource-no-ash-framework.html), vou criar um primeiro Resource no Ash para mostrar como esse contrato aparece no código.

--- a/posts/2025-09-15-criando-seu-primeiro-resource-no-ash-framework.md
+++ b/posts/2025-09-15-criando-seu-primeiro-resource-no-ash-framework.md
@@ -4,13 +4,13 @@ date: 2025-09-15 09:00:00
 tags: ash, ashframework, elixir, phoenix, ptbr
 ---
 
-Nos posts anteriores, falei sobre o problema que o [Ash Framework](https://ash-hq.org/) tenta resolver e comparei Ash com o caminho mais comum em Phoenix: Contexts com [Ecto](https://hexdocs.pm/ecto/Ecto.html).
+No [post anterior da série](/posts/2025-09-08-ash-vs-ecto-contexts-quando-usar.html), comparei Ash com o caminho mais comum em Phoenix: Contexts com [Ecto](https://hexdocs.pm/ecto/Ecto.html).
 
 Agora dá para descer um nível e olhar para a peça mais importante do Ash: o Resource.
 
-Um Resource é a forma como Ash modela um conceito do domínio. Pode ser `Product`, `Customer`, `Invoice`, `Task`, `Post`, `Organization`, `Subscription`. O nome não importa tanto quanto a ideia: um Resource não é apenas uma tabela ou uma struct. Ele descreve atributos, relacionamentos, ações, validações e outras regras ligadas àquele conceito.
+Um Resource é a forma como Ash modela um conceito do domínio. Pode ser `Product`, `Customer`, `Invoice`, `Task`, `Post`, `Organization`, `Subscription`. O nome não importa tanto quanto a ideia: um Resource não é apenas uma tabela ou uma struct. Ele descreve atributos, relacionamentos, ações, validações e outras regras ligadas a esse conceito.
 
-Se você vem de Ecto, a tentação é pensar: "Resource é o schema do Ash". Essa comparação ajuda no começo, mas fica incompleta rápido. Um schema Ecto descreve dados e parte da validação de entrada. Um Resource Ash também descreve quais operações existem para aquele dado.
+Se você usa Ecto, a tentação é pensar: "Resource é o schema do Ash". Essa comparação ajuda no começo, mas fica incompleta rapidamente. Um schema Ecto descreve dados e parte da validação de entrada. Um Resource Ash também descreve quais operações existem para aquele dado.
 
 É essa diferença que faz o Resource ser interessante.
 
@@ -45,7 +45,12 @@ defmodule MyApp.Catalog.Product do
   end
 
   actions do
-    defaults [:read, :destroy, create: [:name, :description], update: [:name, :description, :status]]
+    defaults [
+      :read,
+      :destroy,
+      create: [:name, :description],
+      update: [:name, :description, :status]
+    ]
   end
 end
 ```
@@ -108,13 +113,13 @@ Mas o Domain em Ash não é apenas um módulo com funções soltas. Ele conhece 
 
 Um domínio de catálogo poderia agrupar `Product`, `Category`, `PriceList` e `InventoryItem`. Um domínio de contas poderia agrupar `User`, `Organization`, `Membership` e `Invitation`.
 
-Essa organização ajuda a manter o mapa mental da aplicação. Recursos relacionados ficam próximos, sem transformar um único módulo em uma gaveta de funções.
+Essa organização ajuda a manter o mapa mental da aplicação. Resources relacionados ficam próximos, sem transformar um único módulo em uma gaveta de funções.
 
 ## O que ainda não apareceu
 
 Um Resource real pode ter muito mais coisa:
 
-- relacionamentos;
+- relationships;
 - identities;
 - validations;
 - changes;
@@ -146,11 +151,11 @@ def archive_product(product) do
 end
 ```
 
-Isso é simples e correto. Com Ash, a ideia é que `archive` possa ser uma action do Resource. Assim, autorização, validação e outros comportamentos podem se ligar a essa operação nomeada.
+Essa abordagem funciona bem. Com Ash, a ideia é que `archive` possa ser uma action do Resource. Assim, autorização, validação e outros comportamentos podem se ligar a essa operação nomeada.
 
 Não é que uma abordagem seja sempre melhor. A diferença é onde o contrato aparece.
 
-## Fechando
+## Concluindo
 
 Criar um Resource no Ash é começar a desenhar o domínio de forma declarativa.
 
@@ -158,4 +163,4 @@ O exemplo de `Product` mostra só o básico, mas já apresenta a mudança de per
 
 Quando a aplicação é pequena, isso pode parecer apenas outra forma de escrever o que você já faria com Ecto. Quando o domínio cresce, porém, ter esse contrato explícito ajuda bastante.
 
-No próximo post, vou entrar em actions, changesets e queries com mais detalhe, porque é ali que o Resource deixa de ser apenas uma descrição e começa a virar a API real do domínio.
+No [próximo post da série](/posts/2025-09-22-actions-changesets-e-queries-no-ash.html), vou entrar em actions, changesets e queries com mais detalhe, porque é ali que o Resource deixa de ser apenas uma descrição e começa a virar a API real do domínio.

--- a/posts/2025-09-22-actions-changesets-e-queries-no-ash.md
+++ b/posts/2025-09-22-actions-changesets-e-queries-no-ash.md
@@ -4,6 +4,8 @@ date: 2025-09-22 09:00:00
 tags: ash, ashframework, elixir, phoenix, ptbr
 ---
 
+No [post anterior da série](/posts/2025-09-15-criando-seu-primeiro-resource-no-ash-framework.html), criei um primeiro Resource no Ash e mostrei como atributos e actions começam a aparecer juntos.
+
 Quando começamos a usar [Ash](https://ash-hq.org/), é comum prestar atenção primeiro nos Resources. Eles parecem a parte mais visível: atributos, relacionamentos, validações e configurações ficam todos ali.
 
 Mas o ponto em que Ash realmente começa a mudar a modelagem da aplicação é nas actions.
@@ -20,7 +22,12 @@ Um Resource pode expor ações padrão:
 
 ```elixir
 actions do
-  defaults [:read, :destroy, create: [:name], update: [:name, :status]]
+  defaults [
+    :read,
+    :destroy,
+    create: [:name],
+    update: [:name, :status]
+  ]
 end
 ```
 
@@ -162,7 +169,7 @@ Uma boa pergunta é: "essa operação teria o mesmo nome se eu explicasse o sist
 
 Se sim, provavelmente vale uma action. Se não, talvez seja apenas um detalhe de interface ou uma preparação interna.
 
-## Fechando
+## Concluindo
 
 Actions, changesets e queries são o ponto em que Ash começa a mostrar seu valor além da estrutura.
 
@@ -170,4 +177,4 @@ Actions nomeiam operações. Changesets representam tentativas de executar essas
 
 Isso não elimina a necessidade de pensar em arquitetura. Mas ajuda a tirar regras importantes de lugares espalhados e trazê-las para uma API mais explícita.
 
-No próximo post, vou falar sobre authorization policies, uma das partes em que essa abordagem declarativa fica ainda mais útil.
+No [próximo post da série](/posts/2025-09-29-autorizacao-com-policies-no-ash.html), vou falar sobre authorization policies, uma das partes em que essa abordagem declarativa fica ainda mais útil.

--- a/posts/2025-09-29-autorizacao-com-policies-no-ash.md
+++ b/posts/2025-09-29-autorizacao-com-policies-no-ash.md
@@ -4,13 +4,15 @@ date: 2025-09-29 09:00:00
 tags: ash, ashframework, elixir, phoenix, ptbr
 ---
 
+No [post anterior da série](/posts/2025-09-22-actions-changesets-e-queries-no-ash.html), falei sobre actions, changesets e queries como contrato do domínio.
+
 Autorização é uma daquelas partes da aplicação que parecem simples no começo e viram dívida rápido.
 
 O primeiro `if current_user.admin?` parece inofensivo. Depois aparece um `if user_id == record.user_id` em uma LiveView. Depois uma API precisa repetir a regra. Depois um worker roda sem usuário, mas precisa executar uma ação administrativa. Depois alguém adiciona multi-tenancy e toda query precisa lembrar do `organization_id`.
 
 O problema não é usar `if`. O problema é autorização virar uma coleção de decisões espalhadas.
 
-No [Ash Framework](https://ash-hq.org/), policies tentam trazer essas decisões para perto do domínio. Em vez de cada interface decidir sozinha quem pode fazer o quê, o Resource declara regras de autorização que se aplicam às actions.
+No [Ash Framework](https://ash-hq.org/), policies tentam trazer essas decisões para perto do domínio. Em vez de cada interface decidir sozinha quem pode fazer o que, o Resource declara regras de autorização que se aplicam às actions.
 
 ## Autorização não pertence só ao controller
 
@@ -132,10 +134,12 @@ Policies começam a fazer diferença quando a aplicação tem:
 
 Nesses cenários, autorização deixa de ser detalhe de interface e vira parte central do sistema.
 
-## Fechando
+## Concluindo
 
 Policies no Ash não removem a necessidade de pensar em segurança. Elas apenas colocam a conversa no lugar certo: o domínio.
 
 Em vez de espalhar `if current_user.admin?` por controllers, LiveViews e services, você declara quem pode executar quais actions nos Resources. Isso torna a regra mais visível, mais reaproveitável e mais difícil de esquecer.
 
 O ganho real não é escrever menos código. É reduzir autorização acidental e transformar permissões em parte explícita do contrato da aplicação.
+
+No [próximo post da série](/posts/2025-10-06-ash-phoenix-liveview-formularios-validacoes-crud.html), vou conectar Ash com Phoenix LiveView em formulários, validações e CRUD.

--- a/posts/2025-10-06-ash-phoenix-liveview-formularios-validacoes-crud.md
+++ b/posts/2025-10-06-ash-phoenix-liveview-formularios-validacoes-crud.md
@@ -4,6 +4,8 @@ date: 2025-10-06 09:00:00
 tags: ash, ashframework, elixir, phoenix, liveview, ptbr
 ---
 
+No [post anterior da série](/posts/2025-09-29-autorizacao-com-policies-no-ash.html), falei sobre autorização com policies no Ash e como trazer regras de permissão para perto do domínio.
+
 [Phoenix LiveView](https://hexdocs.pm/phoenix_live_view/) mudou bastante a forma como muita gente escreve interface em Elixir. Em vez de separar tudo entre backend JSON e frontend JavaScript, dá para construir experiências interativas mantendo boa parte da lógica no servidor.
 
 Isso combina bem com [Ash](https://ash-hq.org/), porque Ash também empurra uma parte importante da lógica para um contrato no servidor: Resources, actions, validações, policies e queries.
@@ -139,7 +141,7 @@ Também precisa entender AshPhoenix. Se a equipe tentar usar formulários Ash se
 
 O ganho vem quando o domínio está bem modelado. Se o Resource está confuso, o formulário também vai refletir essa confusão.
 
-## Fechando
+## Concluindo
 
 Ash e Phoenix LiveView se encaixam bem porque os dois valorizam lógica no servidor, mas em camadas diferentes.
 
@@ -148,3 +150,5 @@ LiveView resolve interação e atualização de interface. Ash resolve contrato 
 O resultado não é uma aplicação sem código. É uma aplicação com menos duplicação entre UI e domínio.
 
 Para mim, esse é o ponto mais útil: o formulário deixa de ser o lugar onde a regra é recriada e passa a ser uma entrada bem comportada para actions que já existem.
+
+No [próximo post da série](/posts/2025-10-13-multi-tenancy-com-ash-base-para-saas-em-elixir.html), vou entrar em multi-tenancy com Ash e como isso vira base para SaaS em Elixir.

--- a/posts/2025-10-13-multi-tenancy-com-ash-base-para-saas-em-elixir.md
+++ b/posts/2025-10-13-multi-tenancy-com-ash-base-para-saas-em-elixir.md
@@ -4,6 +4,8 @@ date: 2025-10-13 09:00:00
 tags: ash, ashframework, elixir, phoenix, multitenancy, saas, ptbr
 ---
 
+No [post anterior da série](/posts/2025-10-06-ash-phoenix-liveview-formularios-validacoes-crud.html), conectei Ash com Phoenix LiveView em formulários, validações e CRUD.
+
 Multi-tenancy é um daqueles temas que parecem simples até a aplicação começar a crescer.
 
 No começo, "tenant" parece só um `organization_id` em algumas tabelas. Você adiciona o campo, coloca um filtro nas queries principais e segue. Depois aparecem convites, papéis, integrações, relatórios, webhooks, imports, painel administrativo e jobs. Aos poucos, a pergunta deixa de ser "tem organization_id?" e vira "todas as partes do sistema respeitam o tenant certo?".
@@ -79,7 +81,7 @@ Em um SaaS real, tenant aparece em vários lugares:
 
 Se o tenant é apenas um parâmetro solto em queries, cada uma dessas áreas precisa repetir a mesma regra. Quando o tenant faz parte do contrato do domínio, fica mais natural exigir essa informação em toda operação relevante.
 
-Isso também conversa com policies. Não basta a query filtrar por organização; o actor também precisa ter permissão dentro daquela organização. Multi-tenancy responde "qual espaço de dados?". Autorização responde "quem pode fazer o quê dentro desse espaço?".
+Isso também conversa com policies. Não basta a query filtrar por organização; o actor também precisa ter permissão dentro daquela organização. Multi-tenancy responde "qual espaço de dados?". Autorização responde "quem pode fazer o que dentro desse espaço?".
 
 As duas coisas se complementam.
 
@@ -138,10 +140,12 @@ Eu testaria pelo menos:
 
 Esses testes não são burocracia. Eles protegem uma das promessas básicas de qualquer SaaS: dados de um cliente não aparecem para outro.
 
-## Fechando
+## Concluindo
 
 Multi-tenancy com Ash é interessante porque traz o tenant para o contrato do domínio.
 
 Em vez de depender de filtros manuais espalhados, você declara que certos Resources pertencem a um tenant e executa actions dentro desse contexto. Isso não remove a necessidade de boa modelagem, mas reduz uma fonte comum de erro.
 
 Para SaaS em Elixir, esse é um dos pontos em que Ash pode pagar o custo da curva de aprendizado. Quando isolamento de dados vira regra central do produto, faz sentido que essa regra apareça no domínio, não só em queries soltas.
+
+No [próximo post da série](/posts/2025-10-20-ash-authentication-na-pratica-login-usuario-sessao.html), vou falar sobre Ash Authentication na prática: login, usuário e sessão.

--- a/posts/2025-10-20-ash-authentication-na-pratica-login-usuario-sessao.md
+++ b/posts/2025-10-20-ash-authentication-na-pratica-login-usuario-sessao.md
@@ -4,6 +4,8 @@ date: 2025-10-20 09:00:00
 tags: ash, ashframework, elixir, phoenix, authentication, ptbr
 ---
 
+No [post anterior da série](/posts/2025-10-13-multi-tenancy-com-ash-base-para-saas-em-elixir.html), falei sobre multi-tenancy com Ash como base para aplicações SaaS em Elixir.
+
 Autenticação é uma parte estranha das aplicações web. Todo produto precisa, quase todo framework oferece algum caminho, e mesmo assim é fácil errar detalhes.
 
 Usuário, senha, hash, confirmação de e-mail, reset de senha, sessão, token, login social, API key, expiração, revogação. Nada disso é exatamente regra de negócio do produto, mas tudo isso sustenta o acesso ao produto.
@@ -138,10 +140,12 @@ Se a aplicação é Phoenix simples, com poucos requisitos e sem Ash no domínio
 
 Como quase sempre, a resposta depende do custo de adoção. Ash Authentication brilha quando ele reduz divergência e encaixa em uma arquitetura Ash já existente.
 
-## Fechando
+## Concluindo
 
 Ash Authentication não transforma autenticação em um detalhe irrelevante. Login, sessão e token continuam sendo partes sensíveis da aplicação.
 
 O que ele oferece é uma forma de declarar autenticação junto ao domínio Ash, conectando usuário, estratégia, sessão e actor de maneira mais padronizada.
 
 Para aplicações Phoenix que já apostam em Ash, isso pode reduzir bastante código repetido e deixar mais clara a linha entre identidade e permissão.
+
+No [próximo post da série](/posts/2025-10-27-calculations-e-aggregates-no-ash.html), vou entrar em calculations e aggregates para modelar dados derivados no domínio.

--- a/posts/2025-10-27-calculations-e-aggregates-no-ash.md
+++ b/posts/2025-10-27-calculations-e-aggregates-no-ash.md
@@ -4,6 +4,8 @@ date: 2025-10-27 09:00:00
 tags: ash, ashframework, elixir, phoenix, ptbr
 ---
 
+No [post anterior da série](/posts/2025-10-20-ash-authentication-na-pratica-login-usuario-sessao.html), falei sobre Ash Authentication na prática: login, usuário e sessão.
+
 Nem todo dado importante nasce como coluna no banco.
 
 Um nome completo pode vir de `first_name` e `last_name`. O total de um pedido pode vir da soma dos itens. O status de uma assinatura pode depender de datas, pagamentos e cancelamentos. A quantidade de comentários de um post pode vir de um relacionamento.
@@ -146,10 +148,12 @@ Eu evitaria quando o valor é puramente visual e usado em um único lugar. Nem t
 
 O critério é o mesmo de outras partes do Ash: se faz parte do contrato do domínio, vale modelar.
 
-## Fechando
+## Concluindo
 
 Calculations e aggregates ajudam a tratar dados derivados como cidadãos de primeira classe.
 
 Em vez de espalhar soma, contagem e formatação semântica por templates, APIs e contexts, você coloca a regra perto do Resource. Isso melhora consistência e torna o domínio mais legível.
 
 O ganho não é só conveniência. É clareza. Quando `full_name`, `orders_count` ou `total_spent` têm um dono, fica mais fácil entender o que a aplicação quer dizer com esses valores.
+
+No [próximo post da série](/posts/2025-11-03-vale-a-pena-usar-ash-em-producao.html), vou fechar com uma pergunta prática: vale a pena usar Ash em produção?

--- a/posts/2025-11-03-vale-a-pena-usar-ash-em-producao.md
+++ b/posts/2025-11-03-vale-a-pena-usar-ash-em-producao.md
@@ -4,6 +4,8 @@ date: 2025-11-03 09:00:00
 tags: ash, ashframework, elixir, phoenix, ptbr
 ---
 
+No [post anterior da série](/posts/2025-10-27-calculations-e-aggregates-no-ash.html), falei sobre calculations e aggregates no Ash para modelar dados derivados.
+
 Depois de falar sobre Resources, actions, policies, LiveView, multi-tenancy, autenticação, calculations e aggregates, sobra a pergunta mais importante:
 
 Vale a pena usar [Ash Framework](https://ash-hq.org/) em produção?

--- a/templates/base.html.eex
+++ b/templates/base.html.eex
@@ -10,6 +10,7 @@
     <link rel="icon" href="<%= asset("images/favicon.ico") %>" type="image/x-icon">
 
     <link rel="stylesheet" href="<%= asset("css/style.css") %>">
+    <link rel="stylesheet" href="<%= asset("css/site.css") %>">
     <link rel="stylesheet" href="<%= asset("css/prism.css") %>">
 
     <style>

--- a/templates/post.html.eex
+++ b/templates/post.html.eex
@@ -8,4 +8,7 @@
     <% end %>
   </ul>
 <% end %>
+<%= if @page.extras["series"] == "adotando-pratica-de-notas" do %>
+  <%= render("series-adotando-pratica-de-notas", page: @page) %>
+<% end %>
 <%= @contents %>


### PR DESCRIPTION
## Summary

- Add a reusable series navigation block to the Obsidian note-taking posts
- Add previous and next links across the Ash Framework series
- Polish wording and code snippets in the Ash series posts

## Validation

- Ran `mix serum.build`
